### PR TITLE
Stabilize project canvas gestures and edge rendering

### DIFF
--- a/components/graph/GraphCanvas.tsx
+++ b/components/graph/GraphCanvas.tsx
@@ -51,6 +51,7 @@ export function GraphCanvas({
   // Canvas gestures
   const panGesture = Gesture.Pan()
     .minDistance(10)
+    .maxPointers(1)
     .onUpdate((event) => {
       translateX.value = lastTranslateX.value + event.translationX;
       translateY.value = lastTranslateY.value + event.translationY;
@@ -72,14 +73,18 @@ export function GraphCanvas({
   // Two-finger tap for node creation
   const twoFingerTapGesture = Gesture.Tap()
     .numberOfTaps(1)
-    .maxDuration(300)
+    .numberOfPointers(2)
+    .maxDistance(20)
+    .maxDuration(250)
     .onEnd((event) => {
-      if (event.numberOfPointers >= 2 && onCanvasPress) {
+      if (onCanvasPress) {
         const canvasX = (event.x - translateX.value) / scale.value;
         const canvasY = (event.y - translateY.value) / scale.value;
         runOnJS(onCanvasPress)({ x: canvasX, y: canvasY });
       }
     });
+
+  twoFingerTapGesture.requireExternalGestureToFail(pinchGesture);
 
   const composedGesture = Gesture.Simultaneous(
     panGesture,

--- a/components/graph/GraphEdge.tsx
+++ b/components/graph/GraphEdge.tsx
@@ -52,8 +52,9 @@ export function GraphEdge({ from, to, strokeWidth = 2, color = '#0E7AFE' }: Grap
       y: cAnchor.y + sideVec(cSide).y * pad 
     };
 
-    const pts = [pOut, ...orthogonalWaypoints(pOut, cIn, pSide, cSide), cAnchor];
-    const d = toRoundedSvgPath(pts, 10);
+    const midPoints = orthogonalWaypoints(pOut, cIn, pSide, cSide);
+    const pts = [pAnchor, pOut, ...midPoints, cIn, cAnchor];
+    const d = toRoundedSvgPath(pts, 12);
     return { d } as any;
   });
 

--- a/components/graph/GraphNode.tsx
+++ b/components/graph/GraphNode.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect } from 'react';
-import { View, Text, Platform, TouchableOpacity, StyleSheet } from 'react-native';
-import Animated, { 
-  useAnimatedGestureHandler, 
-  useAnimatedStyle, 
+import { View, Text, Platform, TouchableOpacity } from 'react-native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
   runOnJS,
   useSharedValue,
-  withSpring 
+  withSpring
 } from 'react-native-reanimated';
-import { PanGestureHandler, LongPressGestureHandler } from 'react-native-gesture-handler';
 import { useColorScheme } from 'react-native';
 import { Colors } from '@/constants/Colors';
 import { useGraphRegistry } from './GraphRegistry';
@@ -46,7 +45,8 @@ export function GraphNode({
   const w = useSharedValue(200);
   const h = useSharedValue(120);
   const scale = useSharedValue(1);
-  const isDragging = useSharedValue(false);
+  const startX = useSharedValue(initialX);
+  const startY = useSharedValue(initialY);
 
   const { register, unregister } = useGraphRegistry();
 
@@ -70,122 +70,123 @@ export function GraphNode({
     if (Math.abs(h.value - height) > 1) h.value = height;
   };
 
-  const panHandler = useAnimatedGestureHandler({
-    onStart: (evt, ctx: any) => { 
-      ctx.sx = x.value; 
-      ctx.sy = y.value;
-      isDragging.value = true;
+  const panGesture = Gesture.Pan()
+    .minDistance(2)
+    .maxPointers(1)
+    .shouldCancelWhenOutside(false)
+    .onBegin(() => {
+      startX.value = x.value;
+      startY.value = y.value;
       scale.value = withSpring(1.05);
-    },
-    onActive: (evt, ctx: any) => {
-      x.value = ctx.sx + evt.translationX; 
-      y.value = ctx.sy + evt.translationY;
-    },
-    onEnd: () => { 
-      isDragging.value = false;
+    })
+    .onUpdate((event) => {
+      x.value = startX.value + event.translationX;
+      y.value = startY.value + event.translationY;
+    })
+    .onFinalize(() => {
       scale.value = withSpring(1);
       if (onCommit) {
         runOnJS(onCommit)(id, x.value, y.value);
       }
-    }
-  });
+    });
 
-  const longPressHandler = useAnimatedGestureHandler({
-    onStart: () => {
+  const longPressGesture = Gesture.LongPress()
+    .minDuration(500)
+    .maxDistance(20)
+    .onStart(() => {
       if (onLongPress) {
         runOnJS(onLongPress)();
       }
-    }
-  });
+    });
+
+  const nodeGesture = Gesture.Simultaneous(panGesture, longPressGesture);
 
   const handlePress = () => {
     if (onPress) onPress();
   };
 
   return (
-    <LongPressGestureHandler onGestureEvent={longPressHandler} minDurationMs={500}>
+    <GestureDetector gesture={nodeGesture}>
       <Animated.View>
-        <PanGestureHandler onGestureEvent={panHandler}>
-          <Animated.View 
-            onLayout={onLayout} 
-            style={[
-              {
-                position: 'absolute',
-                padding: 12,
+        <Animated.View
+          onLayout={onLayout}
+          style={[
+            {
+              position: 'absolute',
+              padding: 12,
+              borderRadius: 12,
+              backgroundColor: colors.card,
+              borderWidth: 2,
+              borderColor: colors.primary,
+              minWidth: 180,
+              maxWidth: 220,
+              ...Platform.select({
+                default: {
+                  shadowColor: colors.shadow,
+                  shadowOffset: { width: 0, height: 2 },
+                  shadowOpacity: 0.1,
+                  shadowRadius: 8,
+                  elevation: 4,
+                },
+                web: {
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                  cursor: 'grab',
+                  touchAction: 'none',
+                },
+              }),
+            },
+            animatedStyle
+          ]}
+        >
+          <TouchableOpacity onPress={handlePress} activeOpacity={0.7}>
+            {/* Header */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
+              <View style={{
+                width: 24,
+                height: 24,
                 borderRadius: 12,
-                backgroundColor: colors.card,
-                borderWidth: 2,
-                borderColor: colors.primary,
-                minWidth: 180,
-                maxWidth: 220,
-                ...Platform.select({
-                  default: {
-                    shadowColor: colors.shadow,
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.1,
-                    shadowRadius: 8,
-                    elevation: 4,
-                  },
-                  web: {
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                    cursor: 'grab',
-                    touchAction: 'none',
-                  },
-                }),
-              },
-              animatedStyle
-            ]}
-          >
-            <TouchableOpacity onPress={handlePress} activeOpacity={0.7}>
-              {/* Header */}
-              <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-                <View style={{
-                  width: 24,
-                  height: 24,
-                  borderRadius: 12,
-                  backgroundColor: colors.primary,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginRight: 8,
-                }}>
-                  <Circle size={12} color="#FFFFFF" />
-                </View>
-                {status && <StatusChip status={status} size="small" />}
-              </View>
-
-              {/* Title */}
-              <Text style={{ 
-                fontWeight: '600', 
-                fontSize: 14,
-                color: colors.text,
-                marginBottom: 4,
-                lineHeight: 18,
-              }}>
-                {title}
-              </Text>
-
-              {/* Footer */}
-              <View style={{ 
-                flexDirection: 'row', 
-                justifyContent: 'space-between', 
+                backgroundColor: colors.primary,
                 alignItems: 'center',
-                marginTop: 8 
+                justifyContent: 'center',
+                marginRight: 8,
               }}>
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                  {attachments && attachments.length > 0 && (
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
-                      <Paperclip size={12} color={colors.textSecondary} />
-                      <Text style={{ fontSize: 10, color: colors.textSecondary }}>
-                        {attachments.length}
-                      </Text>
-                    </View>
-                  )}
-                </View>
+                <Circle size={12} color="#FFFFFF" />
               </View>
-            </TouchableOpacity>
-          </Animated.View>
-        </PanGestureHandler>
+              {status && <StatusChip status={status} size="small" />}
+            </View>
+
+            {/* Title */}
+            <Text style={{
+              fontWeight: '600',
+              fontSize: 14,
+              color: colors.text,
+              marginBottom: 4,
+              lineHeight: 18,
+            }}>
+              {title}
+            </Text>
+
+            {/* Footer */}
+            <View style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginTop: 8
+            }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                {attachments && attachments.length > 0 && (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+                    <Paperclip size={12} color={colors.textSecondary} />
+                    <Text style={{ fontSize: 10, color: colors.textSecondary }}>
+                      {attachments.length}
+                    </Text>
+                  </View>
+                )}
+              </View>
+            </View>
+          </TouchableOpacity>
+        </Animated.View>
       </Animated.View>
-    </LongPressGestureHandler>
+    </GestureDetector>
   );
 }

--- a/utils/graphUtils.ts
+++ b/utils/graphUtils.ts
@@ -38,23 +38,28 @@ export function anchorFromSide(r: RectLike, s: Side) {
 }
 
 // Basic orthogonal path with rounded corners
-export function orthogonalWaypoints(out: {x: number; y: number}, inn: {x: number; y: number}, parentSide: Side, childSide: Side) {
+export function orthogonalWaypoints(
+  out: {x: number; y: number},
+  inn: {x: number; y: number},
+  parentSide: Side,
+  childSide: Side
+) {
   'worklet';
-  const pts = [out];
+  const pts: {x: number; y: number}[] = [];
   const bothH = (parentSide === 'left' || parentSide === 'right') && (childSide === 'left' || childSide === 'right');
   const bothV = (parentSide === 'top' || parentSide === 'bottom') && (childSide === 'top' || childSide === 'bottom');
-  
+
   if (bothH) {
-    const midX = (out.x + inn.x)/2; 
-    pts.push({x: midX, y: out.y}, {x: midX, y: inn.y});
+    const midX = (out.x + inn.x) / 2;
+    pts.push({ x: midX, y: out.y }, { x: midX, y: inn.y });
   } else if (bothV) {
-    const midY = (out.y + inn.y)/2; 
-    pts.push({x: out.x, y: midY}, {x: inn.x, y: midY});
+    const midY = (out.y + inn.y) / 2;
+    pts.push({ x: out.x, y: midY }, { x: inn.x, y: midY });
   } else {
     // choose an L that is less likely to cross nodes; start simple
-    pts.push({x: out.x, y: inn.y});
+    pts.push({ x: out.x, y: inn.y });
   }
-  pts.push(inn);
+
   return pts;
 }
 


### PR DESCRIPTION
## Summary
- require true two-finger taps before creating nodes and guard canvas panning so multi-touch behaves consistently on Android and iOS
- migrate graph node dragging and long-press handling to the new gesture API for more reliable interactions across platforms
- update edge routing to originate from the nearest node edges and keep rounded connectors for cleaner arrows

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f832d598832a85268d3454868fa6