### PR TITLE
Fix two-finger tap gesture configuration

### DIFF
--- a/components/graph/GraphCanvas.tsx
+++ b/components/graph/GraphCanvas.tsx
@@ -73,11 +73,15 @@ export function GraphCanvas({
   // Two-finger tap for node creation
   const twoFingerTapGesture = Gesture.Tap()
     .numberOfTaps(1)
-    .numberOfPointers(2)
+    .minPointers(2)
 
     .maxDistance(20)
     .maxDuration(250)
-    .onEnd((event) => {
+    .onEnd((event, successful) => {
+      if (!successful || event.numberOfPointers < 2) {
+        return;
+      }
+
       if (onCanvasPress) {
         const canvasX = (event.x - translateX.value) / scale.value;
         const canvasY = (event.y - translateY.value) / scale.value;


### PR DESCRIPTION
## Summary
- replace the unsupported `numberOfPointers` call on the tap gesture with `minPointers`
- guard the canvas press handler so it only fires for successful two-pointer taps

## Testing
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fc77a8e8832abc3abbe7c61b9e05