### PR TITLE
Ensure native compatibility for modals and framework hook

### DIFF
--- a/components/project/EnhancedNodeCard.tsx
+++ b/components/project/EnhancedNodeCard.tsx
@@ -439,7 +439,7 @@ export function EnhancedNodeCard({
       <Modal
         visible={showDrawing}
         animationType="slide"
-        presentationStyle="pageSheet"
+        presentationStyle={Platform.OS === 'ios' ? 'pageSheet' : 'fullScreen'}
         onRequestClose={() => setShowDrawing(false)}
       >
         <View style={[styles.modalContainer, { backgroundColor: colors.background }]}>
@@ -468,7 +468,7 @@ export function EnhancedNodeCard({
       <Modal
         visible={showAttachments}
         animationType="slide"
-        presentationStyle="pageSheet"
+        presentationStyle={Platform.OS === 'ios' ? 'pageSheet' : 'fullScreen'}
         onRequestClose={() => setShowAttachments(false)}
       >
         <View style={[styles.modalContainer, { backgroundColor: colors.background }]}>

--- a/components/project/NodeEditor.tsx
+++ b/components/project/NodeEditor.tsx
@@ -283,7 +283,7 @@ export function NodeEditor({ node, visible, onClose, onSave, onDelete }: NodeEdi
     <Modal
       visible={visible}
       animationType="slide"
-      presentationStyle="pageSheet"
+      presentationStyle={Platform.OS === 'ios' ? 'pageSheet' : 'fullScreen'}
       onRequestClose={onClose}
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>

--- a/components/ui/DrawingCanvas.tsx
+++ b/components/ui/DrawingCanvas.tsx
@@ -131,7 +131,7 @@ export function DrawingCanvas({ visible, onClose, onSave, initialDrawing }: Draw
     <Modal
       visible={visible}
       animationType="slide"
-      presentationStyle="pageSheet"
+      presentationStyle={Platform.OS === 'ios' ? 'pageSheet' : 'fullScreen'}
       onRequestClose={handleClose}
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>

--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,13 +1,11 @@
 import { useEffect } from 'react';
 
-declare global {
-  interface Window {
-    frameworkReady?: () => void;
-  }
-}
+type FrameworkReadyScope = typeof globalThis & { frameworkReady?: () => void };
 
 export function useFrameworkReady() {
   useEffect(() => {
-    window.frameworkReady?.();
-  });
+    if (typeof globalThis !== 'undefined') {
+      (globalThis as FrameworkReadyScope).frameworkReady?.();
+    }
+  }, []);
 }


### PR DESCRIPTION
## Summary
- update modal presentation styles to fall back to full screen on non-iOS platforms for the drawing canvas, node editor, and enhanced node card
- guard the framework ready hook to use globalThis safely on native platforms

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d37ddb9b78832a90f47921704378b6