### PR TITLE
Improve cross-platform layout responsiveness

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,7 +7,6 @@ import {
   SafeAreaView,
   RefreshControl,
   TouchableOpacity,
-  Dimensions,
 } from 'react-native';
 import { useColorScheme } from 'react-native';
 import { Colors } from '@/constants/Colors';
@@ -22,8 +21,6 @@ import { Workspace, Project, Node, Reminder } from '@/types';
 import { FloatingActionButton } from '@/components/ui/FloatingActionButton';
 import { useUser } from '@/contexts/UserContext';
 import { Alert } from 'react-native';
-
-const { width } = Dimensions.get('window');
 
 export default function DashboardScreen() {
   const colorScheme = useColorScheme();

--- a/components/graph/GraphCanvas.tsx
+++ b/components/graph/GraphCanvas.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Dimensions, TouchableOpacity, Text, Platform } from 'react-native';
+import { View, TouchableOpacity, Text, Platform, useWindowDimensions } from 'react-native';
 import { useColorScheme } from 'react-native';
 import Svg from 'react-native-svg';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
@@ -17,8 +17,6 @@ import { GraphNode } from './GraphNode';
 import { GraphEdge } from './GraphEdge';
 import { Plus, RotateCcw, ZoomIn, ZoomOut } from 'lucide-react-native';
 
-const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const CANVAS_SIZE = { width: screenWidth * 2, height: screenHeight * 2 };
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 2.0;
 
@@ -45,6 +43,12 @@ export function GraphCanvas({
 }: GraphCanvasProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+
+  const canvasSize = useMemo(() => ({
+    width: Math.max(windowWidth * 2, windowWidth),
+    height: Math.max(windowHeight * 2, windowHeight),
+  }), [windowWidth, windowHeight]);
 
   const edgesToRender = useMemo<GraphCanvasEdge[]>(() => {
     if (edges !== undefined) {
@@ -164,8 +168,8 @@ export function GraphCanvas({
                 position: 'absolute',
                 left: 0,
                 top: 0,
-                width: CANVAS_SIZE.width,
-                height: CANVAS_SIZE.height,
+                width: canvasSize.width,
+                height: canvasSize.height,
                 pointerEvents: 'none',
               }}
             >
@@ -181,11 +185,11 @@ export function GraphCanvas({
             </Svg>
 
             {/* Nodes layer */}
-            <View 
-              style={{ 
+            <View
+              style={{
                 position: 'absolute',
-                width: CANVAS_SIZE.width,
-                height: CANVAS_SIZE.height,
+                width: canvasSize.width,
+                height: canvasSize.height,
               }}
               pointerEvents="box-none"
             >

--- a/components/project/ProjectCanvas.tsx
+++ b/components/project/ProjectCanvas.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
-  Dimensions,
   TouchableOpacity,
   Platform,
   ScrollView,
@@ -28,9 +27,6 @@ interface ProjectCanvasProps {
   onUpdateNode: (nodeId: string, updates: Partial<Node>) => void;
   onCanvasPress: (position: { x: number; y: number }) => void;
 }
-
-const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const CANVAS_SIZE = { width: screenWidth * 2, height: screenHeight * 2 };
 
 export function ProjectCanvas({
   project,

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -6,6 +6,7 @@ import {
   ViewStyle,
   TextStyle,
   ActivityIndicator,
+  StyleProp,
 } from 'react-native';
 import { useColorScheme } from 'react-native';
 import { Colors } from '@/constants/Colors';
@@ -17,8 +18,8 @@ interface ButtonProps {
   size?: 'small' | 'medium' | 'large';
   disabled?: boolean;
   loading?: boolean;
-  style?: ViewStyle;
-  textStyle?: TextStyle;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
 }
 
 export function Button({

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, ViewStyle, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
 import { useColorScheme } from 'react-native';
 import { Colors } from '@/constants/Colors';
 
 interface CardProps {
   children: React.ReactNode;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   elevated?: boolean;
 }
 

--- a/components/ui/DrawingCanvas.tsx
+++ b/components/ui/DrawingCanvas.tsx
@@ -2,11 +2,11 @@ import React, { useRef, useState } from 'react';
 import {
   View,
   StyleSheet,
-  Dimensions,
   TouchableOpacity,
   Text,
   Modal,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
 import { useColorScheme } from 'react-native';
 import Svg, { Path, G } from 'react-native-svg';
@@ -28,16 +28,16 @@ interface PathData {
   strokeWidth: number;
 }
 
-const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const CANVAS_WIDTH = screenWidth - 32;
-const CANVAS_HEIGHT = screenHeight * 0.6;
-
 const COLORS = ['#000000', '#FF3B30', '#007AFF', '#34C759', '#FF9500', '#AF52DE', '#8E8E93'];
 const STROKE_WIDTHS = [2, 4, 6, 8];
 
 export function DrawingCanvas({ visible, onClose, onSave, initialDrawing }: DrawingCanvasProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+
+  const canvasWidth = Math.max(windowWidth - 32, 280);
+  const canvasHeight = Math.max(windowHeight * 0.6, 240);
   
   const [paths, setPaths] = useState<PathData[]>([]);
   const [currentPath, setCurrentPath] = useState<string>('');
@@ -227,8 +227,8 @@ export function DrawingCanvas({ visible, onClose, onSave, initialDrawing }: Draw
           <GestureDetector gesture={panGesture}>
             <View style={styles.canvas}>
               <Svg
-                width={CANVAS_WIDTH}
-                height={CANVAS_HEIGHT}
+                width={canvasWidth}
+                height={canvasHeight}
                 style={styles.svg}
               >
                 <G>

--- a/components/workspace/WorkspaceStack.tsx
+++ b/components/workspace/WorkspaceStack.tsx
@@ -4,7 +4,7 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Dimensions,
+  useWindowDimensions,
 } from 'react-native';
 import { useColorScheme } from 'react-native';
 import Animated, {
@@ -27,14 +27,14 @@ interface WorkspaceStackProps {
   index: number;
 }
 
-const { width } = Dimensions.get('window');
-const CARD_WIDTH = width - 32;
 const STACK_OFFSET = 8;
 const MAX_STACK_ITEMS = 3;
 
-export function WorkspaceStack({ workspace, onPress, onEdit, onDelete, index }: WorkspaceStackProps) {
+export function WorkspaceStack({ workspace, onPress, onEdit, onDelete, index: _index }: WorkspaceStackProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { width } = useWindowDimensions();
+  const cardWidth = Math.max(width - 32, 260);
   
   const pressed = useSharedValue(false);
   const scale = useSharedValue(1);
@@ -74,11 +74,11 @@ export function WorkspaceStack({ workspace, onPress, onEdit, onDelete, index }: 
   const renderStackLayers = () => {
     const layers = [];
     const stackCount = Math.min(workspace.projectCount, MAX_STACK_ITEMS);
-    
+
     for (let i = stackCount - 1; i >= 0; i--) {
       const offset = i * STACK_OFFSET;
       const opacity = interpolate(i, [0, stackCount - 1], [1, 0.3]);
-      
+
       layers.push(
         <View
           key={i}
@@ -93,6 +93,7 @@ export function WorkspaceStack({ workspace, onPress, onEdit, onDelete, index }: 
               ],
               opacity,
               zIndex: -i,
+              width: cardWidth,
             },
           ]}
         />
@@ -108,7 +109,7 @@ export function WorkspaceStack({ workspace, onPress, onEdit, onDelete, index }: 
         <Animated.View style={[styles.container, animatedStyle]}>
           {renderStackLayers()}
           <TouchableOpacity onLongPress={handleLongPress}>
-            <Card style={[styles.card, { borderLeftColor: workspace.color }]}>
+            <Card style={[styles.card, { borderLeftColor: workspace.color, width: cardWidth }]}>
               <View style={styles.header}>
                 <View style={[styles.iconContainer, { backgroundColor: workspace.color }]}>
                   <Briefcase size={20} color="#FFFFFF" />
@@ -168,7 +169,6 @@ const styles = StyleSheet.create({
   },
   stackLayer: {
     position: 'absolute',
-    width: CARD_WIDTH,
     height: 100,
     borderRadius: 12,
     shadowOffset: {


### PR DESCRIPTION
## Summary
- compute graph and drawing canvas bounds from useWindowDimensions so canvas controls adapt to rotation and varied device sizes
- size workspace stacks dynamically per screen width and remove unused static dimensions from shared components
- allow shared Button and Card components to accept StyleProp-based style overrides used throughout native screens

## Testing
- npx tsc --noEmit *(fails: existing type errors in search, graph nodes, enhanced node card, node editor, and graph store)*

------
https://chatgpt.com/codex/tasks/task_e_68da381894c4832a869f6cc5460d3f99