### PR TITLE
Fix Android graph node gesture detection

### DIFF
--- a/components/graph/GraphNode.tsx
+++ b/components/graph/GraphNode.tsx
@@ -118,83 +118,82 @@ export function GraphNode({
 
   return (
     <GestureDetector gesture={nodeGesture}>
-      <Animated.View>
-        <Animated.View
-          onLayout={onLayout}
-          style={[
-            {
-              position: 'absolute',
-              padding: 12,
-              borderRadius: 12,
-              backgroundColor: colors.card,
-              borderWidth: 2,
-              borderColor: accentColor,
-              minWidth: 180,
-              maxWidth: 220,
-              ...Platform.select({
-                default: {
-                  shadowColor: colors.shadow,
-                  shadowOffset: { width: 0, height: 2 },
-                  shadowOpacity: 0.1,
-                  shadowRadius: 8,
-                  elevation: 4,
-                },
-                web: {
-                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                  cursor: 'grab',
-                  touchAction: 'none',
-                },
-              }),
-            },
-            animatedStyle
-          ]}
-        >
-          {/* Header */}
-          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-            <View style={{
-              width: 24,
-              height: 24,
-              borderRadius: 12,
-              backgroundColor: accentColor,
-              alignItems: 'center',
-              justifyContent: 'center',
-              marginRight: 8,
-            }}>
-              <Circle size={12} color="#FFFFFF" />
-            </View>
-            {status && <StatusChip status={status} size="small" />}
-          </View>
-
-          {/* Title */}
-          <Text style={{
-            fontWeight: '600',
-            fontSize: 14,
-            color: colors.text,
-            marginBottom: 4,
-            lineHeight: 18,
-          }}>
-            {title}
-          </Text>
-
-          {/* Footer */}
+      <Animated.View
+        collapsable={false}
+        onLayout={onLayout}
+        style={[
+          {
+            position: 'absolute',
+            padding: 12,
+            borderRadius: 12,
+            backgroundColor: colors.card,
+            borderWidth: 2,
+            borderColor: accentColor,
+            minWidth: 180,
+            maxWidth: 220,
+            ...Platform.select({
+              default: {
+                shadowColor: colors.shadow,
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.1,
+                shadowRadius: 8,
+                elevation: 4,
+              },
+              web: {
+                boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                cursor: 'grab',
+                touchAction: 'none',
+              },
+            }),
+          },
+          animatedStyle,
+        ]}
+      >
+        {/* Header */}
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
           <View style={{
-            flexDirection: 'row',
-            justifyContent: 'space-between',
+            width: 24,
+            height: 24,
+            borderRadius: 12,
+            backgroundColor: accentColor,
             alignItems: 'center',
-            marginTop: 8
+            justifyContent: 'center',
+            marginRight: 8,
           }}>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              {attachments && attachments.length > 0 && (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
-                  <Paperclip size={12} color={colors.textSecondary} />
-                  <Text style={{ fontSize: 10, color: colors.textSecondary }}>
-                    {attachments.length}
-                  </Text>
-                </View>
-              )}
-            </View>
+            <Circle size={12} color="#FFFFFF" />
           </View>
-        </Animated.View>
+          {status && <StatusChip status={status} size="small" />}
+        </View>
+
+        {/* Title */}
+        <Text style={{
+          fontWeight: '600',
+          fontSize: 14,
+          color: colors.text,
+          marginBottom: 4,
+          lineHeight: 18,
+        }}>
+          {title}
+        </Text>
+
+        {/* Footer */}
+        <View style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginTop: 8,
+        }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            {attachments && attachments.length > 0 && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+                <Paperclip size={12} color={colors.textSecondary} />
+                <Text style={{ fontSize: 10, color: colors.textSecondary }}>
+                  {attachments.length}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
       </Animated.View>
     </GestureDetector>
   );


### PR DESCRIPTION
## Summary
- attach the graph node gesture detector to the positioned node container so Android touches register correctly
- mark the animated node view as non-collapsable to ensure layout measurements continue to drive edge rendering

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68da3db1e908832aaec55955bb45742a