### PR TITLE
Improve graph canvas gestures and edge routing

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,8 +21,8 @@ export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <UserProvider>
-      <GestureHandlerRootView style={{ flex: 1 }}>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <UserProvider>
         <>
           <Stack screenOptions={{ headerShown: false }}>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -37,7 +37,7 @@ export default function RootLayout() {
           </Stack>
           <StatusBar style="auto" />
         </>
-      </GestureHandlerRootView>
-    </UserProvider>
+      </UserProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/components/graph/GraphRegistry.tsx
+++ b/components/graph/GraphRegistry.tsx
@@ -1,12 +1,22 @@
 import React, { createContext, useContext, useMemo, useRef, useSyncExternalStore } from 'react';
+import type { RefObject } from 'react';
 import type { SharedValue } from 'react-native-reanimated';
 
-export type SVs = { x: SharedValue<number>; y: SharedValue<number>; w: SharedValue<number>; h: SharedValue<number> };
+type HandlerRef = RefObject<any> | undefined;
+export type SVs = {
+  x: SharedValue<number>;
+  y: SharedValue<number>;
+  w: SharedValue<number>;
+  h: SharedValue<number>;
+  panRef?: HandlerRef;
+  tapRef?: HandlerRef;
+};
 
 type Ctx = {
   register: (id: string, svs: SVs) => void;
   unregister: (id: string) => void;
   get: (id: string) => SVs | undefined;
+  getAll: () => Array<[string, SVs]>;
   subscribe: (cb: () => void) => () => void;
   getSnapshot: () => number;
 };
@@ -24,6 +34,7 @@ export function GraphProvider({ children }: { children: React.ReactNode }) {
     register: (id, svs) => { mapRef.current.set(id, svs); notify(); },
     unregister: (id) => { mapRef.current.delete(id); notify(); },
     get: (id) => mapRef.current.get(id),
+    getAll: () => Array.from(mapRef.current.entries()),
     subscribe: (cb) => { listeners.current.add(cb); return () => listeners.current.delete(cb); },
     getSnapshot: () => versionRef.current,
   }), []);


### PR DESCRIPTION
## Summary
- wrap the root navigator with GestureHandlerRootView to stabilise Android gesture handling
- refactor canvas and node interactions to Pan/Tap/Pinch gesture handlers with shared values and Android-safe measurements
- update edge routing utilities to compute rounded orthogonal paths with pointer-event safe SVG rendering

## Testing
- npm run lint *(fails: ESLint not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68daa731ba88832aaf87e4c1b14038e1