### PR TITLE
Fix Android gesture handler nesting crash

### DIFF
--- a/components/graph/GraphCanvas.tsx
+++ b/components/graph/GraphCanvas.tsx
@@ -244,7 +244,6 @@ function GraphCanvasInner({
                         onPress={() => onNodePress?.(n.id)}
                         onLongPress={() => onNodeLongPress?.(n.id)}
                         canvasPanRef={panRef}
-                        canvasTapRef={tapRef}
                       />
                     ))}
                   </View>

--- a/components/graph/GraphRegistry.tsx
+++ b/components/graph/GraphRegistry.tsx
@@ -9,7 +9,6 @@ export type SVs = {
   w: SharedValue<number>;
   h: SharedValue<number>;
   panRef?: HandlerRef;
-  tapRef?: HandlerRef;
 };
 
 type Ctx = {


### PR DESCRIPTION
## Summary
- replace nested tap/long-press handlers in `GraphNode` with a pressable surface paired with the existing pan gesture to avoid Android native driver crashes
- remove tap handler references from the graph registry and canvas to align with the simplified gesture setup

## Testing
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68dac38f3f48832a9a66f22195969a1b