### PR TITLE
Add Expo tunnel launcher automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ This repo includes a minimal web launcher you can deploy to Railway. It shows a 
 
 **Deploy**
 - Click "New Project" on Railway and connect this repo.
-- After deploy, set the environment variable **EXPO_URL** to your Expo deep link or project page URL (examples below).
+- Railway now boots both the Expo Metro server **and** this launcher page. No separate tunnel step is required.
+- After deploy, review the logs to confirm that the Expo tunnel URL is detected (or set the **EXPO_URL** env var manually as a fallback).
 - Redeploy; visit the Railway URL to see the QR and button.
 
 **Where do I get EXPO_URL?**
-- Development (tunnel): run `npx expo start --tunnel` locally → copy the "Expo Go" link shown in the CLI/DevTools and paste it into Railway as EXPO_URL.
+- Development (tunnel): run `npx expo start --tunnel` locally → copy the "Expo Go" link shown in the CLI/DevTools and paste it into Railway as EXPO_URL (only needed if automatic detection fails).
 - Published (EAS Update or classic publish): use your project page, e.g. `https://expo.dev/@ACCOUNT/SLUG?service=expo-go`.
 - Direct deep link format also works (exp:// or exps://) if provided by Expo.
 
 **Notes**
-- Railway serves only the launcher page; it does not run Metro. Your device connects to Expo’s servers or your tunnel via EXPO_URL.
+- Railway now serves the launcher page **and** runs the Expo Metro dev server through `npx expo start --tunnel`. Scan the QR code on the Railway page to open the live tunnel.
+- If the Expo CLI cannot emit a tunnel URL automatically (for example, if tunnels are disabled), set the **EXPO_URL** environment variable and the launcher will fall back to it.
 - Make sure your phone has **Expo Go** installed.
-

--- a/launcher/server.js
+++ b/launcher/server.js
@@ -2,11 +2,101 @@ import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
 
+import {
+  getExpoStatus,
+  getExpoUrl,
+  isExpoRunning,
+  onExpoUrlUpdate,
+  startExpo,
+} from "./start-expo.js";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+let currentExpoUrl = getExpoUrl() || process.env.EXPO_URL || "";
+let statusPollTimer = null;
+
+function normalizeExpoUrl(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = value.match(/(exp:\/\/[^\s]+|https?:\/\/[^\s]+expo\.[^\s]+)/i);
+  return match ? match[0] : null;
+}
+
+function searchForExpoUrl(data) {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const values = Array.isArray(data) ? data : Object.values(data);
+  for (const value of values) {
+    if (!value) continue;
+    if (typeof value === "string") {
+      const url = normalizeExpoUrl(value);
+      if (url) return url;
+    } else if (typeof value === "object") {
+      const nested = searchForExpoUrl(value);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+async function refreshExpoUrlFromStatus() {
+  try {
+    const status = await getExpoStatus();
+    if (!status) return;
+    const discovered = searchForExpoUrl(status);
+    if (discovered && discovered !== currentExpoUrl) {
+      currentExpoUrl = discovered;
+      console.log(`[launcher] Expo status reported URL: ${discovered}`);
+    }
+  } catch (error) {
+    console.warn("[launcher] Unable to read Expo status:", error);
+  }
+}
+
+function beginStatusPolling() {
+  if (statusPollTimer) return;
+  statusPollTimer = setInterval(() => {
+    if (currentExpoUrl) return;
+    refreshExpoUrlFromStatus();
+  }, Number(process.env.EXPO_STATUS_POLL_INTERVAL || 10000));
+  if (typeof statusPollTimer.unref === "function") {
+    statusPollTimer.unref();
+  }
+}
+
+onExpoUrlUpdate((url) => {
+  currentExpoUrl = url;
+});
+
+async function ensureExpoDevServer() {
+  try {
+    const alreadyRunning = await isExpoRunning();
+    if (alreadyRunning) {
+      console.log("[launcher] Found existing Expo dev server instance.");
+      await refreshExpoUrlFromStatus();
+      return;
+    }
+
+    console.log("[launcher] Starting Expo dev server (tunnel mode)...");
+    startExpo();
+    await refreshExpoUrlFromStatus();
+  } catch (error) {
+    console.error("[launcher] Failed to start Expo dev server:", error);
+  }
+}
+
+ensureExpoDevServer().catch((error) => {
+  console.error("[launcher] Unexpected error while ensuring Expo server:", error);
+});
+
+beginStatusPolling();
 
 // Serve static assets (index.html and client js)
 app.use(express.static(path.join(__dirname, "public")));
@@ -16,8 +106,9 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 // Inject EXPO_URL into the page at runtime if needed
 app.get("/config.js", (_req, res) => {
   res.setHeader("Content-Type", "application/javascript");
-  const EXPO_URL = process.env.EXPO_URL || "";
-  res.end(`window.__EXPO_URL__ = ${JSON.stringify(EXPO_URL)};`);
+  const fallbackUrl = process.env.EXPO_URL || "";
+  const resolvedUrl = currentExpoUrl || fallbackUrl;
+  res.end(`window.__EXPO_URL__ = ${JSON.stringify(resolvedUrl)};`);
 });
 
 app.listen(PORT, () => {

--- a/launcher/start-expo.js
+++ b/launcher/start-expo.js
@@ -1,0 +1,228 @@
+import { spawn } from "child_process";
+import { EventEmitter } from "events";
+import fs from "fs";
+import http from "http";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const expoEvents = new EventEmitter();
+let expoProcess = null;
+let latestExpoUrl = process.env.EXPO_URL || "";
+
+const EXPO_PORT = Number(process.env.EXPO_PORT || 8081);
+const PID_FILE = path.join(__dirname, ".expo-process.json");
+
+function requestExpoStatus() {
+  return new Promise((resolve) => {
+    const request = http.get(
+      {
+        hostname: "127.0.0.1",
+        port: EXPO_PORT,
+        path: "/status",
+        timeout: 2000,
+      },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          raw += chunk;
+        });
+        res.on("end", () => {
+          if (!raw) {
+            resolve({ ok: res.statusCode === 200, data: null });
+            return;
+          }
+          try {
+            const parsed = JSON.parse(raw);
+            resolve({ ok: res.statusCode === 200, data: parsed });
+          } catch (error) {
+            resolve({ ok: res.statusCode === 200, data: null });
+          }
+        });
+      }
+    );
+
+    request.on("error", () => resolve({ ok: false, data: null }));
+    request.on("timeout", () => {
+      request.destroy();
+      resolve({ ok: false, data: null });
+    });
+  });
+}
+
+function parseExpoUrl(text) {
+  const matches = text.match(/(exp:\/\/[^\s]+|https?:\/\/[^\s]+expo\.[^\s]+)/i);
+  if (!matches) {
+    return;
+  }
+  const [match] = matches;
+  if (match && match !== latestExpoUrl) {
+    latestExpoUrl = match.trim();
+    expoEvents.emit("url", latestExpoUrl);
+    console.log(`[launcher] Expo tunnel URL detected: ${latestExpoUrl}`);
+  }
+}
+
+function logStream(stream, prefix) {
+  if (!stream) return;
+  stream.on("data", (chunk) => {
+    const text = chunk.toString();
+    text.split(/\r?\n/).forEach((line, index, arr) => {
+      if (!line && index === arr.length - 1) return;
+      console.log(`${prefix}${line}`);
+    });
+    parseExpoUrl(text);
+  });
+}
+
+function logErrorStream(stream, prefix) {
+  if (!stream) return;
+  stream.on("data", (chunk) => {
+    const text = chunk.toString();
+    text.split(/\r?\n/).forEach((line, index, arr) => {
+      if (!line && index === arr.length - 1) return;
+      console.error(`${prefix}${line}`);
+    });
+  });
+}
+
+function processExists(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+export function getRecordedExpoProcess() {
+  try {
+    const raw = fs.readFileSync(PID_FILE, "utf8");
+    const data = JSON.parse(raw);
+    if (data?.pid && processExists(data.pid)) {
+      return data.pid;
+    }
+  } catch (error) {
+    // ignore read errors
+  }
+  return null;
+}
+
+function recordExpoProcess(pid) {
+  if (!pid) return;
+  try {
+    fs.writeFileSync(PID_FILE, JSON.stringify({ pid }), "utf8");
+  } catch (error) {
+    console.error("[launcher] Failed to persist Expo process PID:", error);
+  }
+}
+
+function clearRecordedProcess() {
+  try {
+    if (fs.existsSync(PID_FILE)) {
+      fs.unlinkSync(PID_FILE);
+    }
+  } catch (error) {
+    console.error("[launcher] Failed to remove Expo process record:", error);
+  }
+}
+
+export function startExpo(options = {}) {
+  const { detached = false, force = false } = options;
+
+  if (!force && expoProcess && !expoProcess.killed) {
+    return expoProcess;
+  }
+
+  if (!force) {
+    const recordedPid = getRecordedExpoProcess();
+    if (recordedPid) {
+      console.log(
+        `[launcher] Detected running Expo process with PID ${recordedPid}. Skipping new spawn.`
+      );
+      return expoProcess;
+    }
+  }
+
+  const projectRoot = path.resolve(__dirname, "..", "");
+
+  const child = spawn("npx", ["expo", "start", "--tunnel"], {
+    cwd: projectRoot,
+    env: { ...process.env },
+    stdio: detached ? "inherit" : ["ignore", "pipe", "pipe"],
+    shell: false,
+    detached,
+  });
+
+  recordExpoProcess(child.pid);
+
+  child.on("error", (error) => {
+    console.error("[launcher] Expo process error:", error);
+  });
+
+  child.on("exit", (code, signal) => {
+    expoProcess = null;
+    clearRecordedProcess();
+    if (code === 0) {
+      console.log("[launcher] Expo process exited cleanly.");
+    } else {
+      console.error(
+        `[launcher] Expo process exited with code ${code}${signal ? ` (signal ${signal})` : ""}.`
+      );
+    }
+  });
+
+  if (detached) {
+    try {
+      child.unref();
+    } catch (error) {
+      console.error("[launcher] Failed to detach Expo process:", error);
+    }
+  } else {
+    logStream(child.stdout, "[expo] ");
+    logErrorStream(child.stderr, "[expo] ");
+  }
+
+  expoProcess = child;
+  return child;
+}
+
+export function getExpoUrl() {
+  return latestExpoUrl;
+}
+
+export function onExpoUrlUpdate(listener) {
+  expoEvents.on("url", listener);
+  if (latestExpoUrl) {
+    listener(latestExpoUrl);
+  }
+  return () => expoEvents.off("url", listener);
+}
+
+export async function isExpoRunning() {
+  if (getRecordedExpoProcess()) {
+    return true;
+  }
+
+  const status = await requestExpoStatus();
+  return status.ok;
+}
+
+export async function getExpoStatus() {
+  const status = await requestExpoStatus();
+  return status.data || null;
+}
+
+if (process.argv[1] === __filename) {
+  const runningCheck = await isExpoRunning();
+  if (runningCheck) {
+    console.log("[launcher] Expo dev server already running. Skipping new spawn.");
+  } else {
+    console.log("[launcher] Starting Expo dev server in detached mode...");
+    startExpo({ detached: true, force: true });
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "numReplicas": 1,
-    "startCommand": "npm --prefix launcher install && npm --prefix launcher start",
+    "startCommand": "npm --prefix launcher install && node launcher/start-expo.js && npm --prefix launcher start",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100
   }


### PR DESCRIPTION
## Summary
- add a reusable launcher/start-expo.js helper that spawns `npx expo start --tunnel`, records the PID, and watches the CLI/status output for tunnel URLs
- update the Express launcher to ensure the Expo server is running, poll the Metro status endpoint for live URLs, and expose them to the client
- document the new Railway flow and update the deployment start command so Metro and the web launcher boot together

## Testing
- not run (Expo CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dff7fa688c832aa8d67493c496476c