### PR TITLE
Automate Expo tunnel detection for Railway launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ This repo includes a minimal web launcher you can deploy to Railway. It shows a 
 - Direct deep link format also works (exp:// or exps://) if provided by Expo.
 
 **Notes**
-- Railway now serves the launcher page **and** runs the Expo Metro dev server through `npx expo start --tunnel`. Scan the QR code on the Railway page to open the live tunnel.
+- Railway now serves the launcher page **and** runs the Expo Metro dev server through `npx expo start --tunnel --non-interactive`. The launcher starts the CLI in the background, parses the Expo URL from logs, writes it to `/config.js`, and renders a live QR code with an "Open in Expo Go" button.
 - If the Expo CLI cannot emit a tunnel URL automatically (for example, if tunnels are disabled), set the **EXPO_URL** environment variable and the launcher will fall back to it.
 - Make sure your phone has **Expo Go** installed.

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "expo": "node start-expo.js",
     "start": "node server.js"
   },
   "dependencies": {

--- a/launcher/server.js
+++ b/launcher/server.js
@@ -1,14 +1,7 @@
 import express from "express";
-import path from "path";
-import { fileURLToPath } from "url";
-
-import {
-  getExpoStatus,
-  getExpoUrl,
-  isExpoRunning,
-  onExpoUrlUpdate,
-  startExpo,
-} from "./start-expo.js";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,99 +9,29 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-let currentExpoUrl = getExpoUrl() || process.env.EXPO_URL || "";
-let statusPollTimer = null;
+const PUBLIC_DIR = path.join(__dirname, "public");
+const RUNTIME_URL_FILE = path.join(__dirname, ".runtime", "expo-url.json");
 
-function normalizeExpoUrl(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const match = value.match(/(exp:\/\/[^\s]+|https?:\/\/[^\s]+expo\.[^\s]+)/i);
-  return match ? match[0] : null;
-}
+app.use(express.static(PUBLIC_DIR));
 
-function searchForExpoUrl(data) {
-  if (!data || typeof data !== "object") {
-    return null;
-  }
-
-  const values = Array.isArray(data) ? data : Object.values(data);
-  for (const value of values) {
-    if (!value) continue;
-    if (typeof value === "string") {
-      const url = normalizeExpoUrl(value);
-      if (url) return url;
-    } else if (typeof value === "object") {
-      const nested = searchForExpoUrl(value);
-      if (nested) return nested;
-    }
-  }
-  return null;
-}
-
-async function refreshExpoUrlFromStatus() {
-  try {
-    const status = await getExpoStatus();
-    if (!status) return;
-    const discovered = searchForExpoUrl(status);
-    if (discovered && discovered !== currentExpoUrl) {
-      currentExpoUrl = discovered;
-      console.log(`[launcher] Expo status reported URL: ${discovered}`);
-    }
-  } catch (error) {
-    console.warn("[launcher] Unable to read Expo status:", error);
-  }
-}
-
-function beginStatusPolling() {
-  if (statusPollTimer) return;
-  statusPollTimer = setInterval(() => {
-    if (currentExpoUrl) return;
-    refreshExpoUrlFromStatus();
-  }, Number(process.env.EXPO_STATUS_POLL_INTERVAL || 10000));
-  if (typeof statusPollTimer.unref === "function") {
-    statusPollTimer.unref();
-  }
-}
-
-onExpoUrlUpdate((url) => {
-  currentExpoUrl = url;
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
 });
 
-async function ensureExpoDevServer() {
-  try {
-    const alreadyRunning = await isExpoRunning();
-    if (alreadyRunning) {
-      console.log("[launcher] Found existing Expo dev server instance.");
-      await refreshExpoUrlFromStatus();
-      return;
-    }
-
-    console.log("[launcher] Starting Expo dev server (tunnel mode)...");
-    startExpo();
-    await refreshExpoUrlFromStatus();
-  } catch (error) {
-    console.error("[launcher] Failed to start Expo dev server:", error);
-  }
-}
-
-ensureExpoDevServer().catch((error) => {
-  console.error("[launcher] Unexpected error while ensuring Expo server:", error);
-});
-
-beginStatusPolling();
-
-// Serve static assets (index.html and client js)
-app.use(express.static(path.join(__dirname, "public")));
-
-app.get("/health", (_req, res) => res.json({ ok: true }));
-
-// Inject EXPO_URL into the page at runtime if needed
 app.get("/config.js", (_req, res) => {
   res.setHeader("Content-Type", "application/javascript");
-  const fallbackUrl = process.env.EXPO_URL || "";
-  const resolvedUrl = currentExpoUrl || fallbackUrl;
-  res.end(`window.__EXPO_URL__ = ${JSON.stringify(resolvedUrl)};`);
+  let url = process.env.EXPO_URL || "";
+  try {
+    if (fs.existsSync(RUNTIME_URL_FILE)) {
+      const data = JSON.parse(fs.readFileSync(RUNTIME_URL_FILE, "utf8"));
+      if (data && data.url) {
+        url = data.url;
+      }
+    }
+  } catch (error) {
+    console.warn("[launcher] Failed to read Expo runtime URL:", error);
+  }
+  res.end(`window.__EXPO_URL__ = ${JSON.stringify(url)};`);
 });
 
 app.listen(PORT, () => {

--- a/launcher/start-expo.js
+++ b/launcher/start-expo.js
@@ -1,228 +1,79 @@
-import { spawn } from "child_process";
-import { EventEmitter } from "events";
-import fs from "fs";
-import http from "http";
-import path from "path";
-import { fileURLToPath } from "url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const expoEvents = new EventEmitter();
-let expoProcess = null;
-let latestExpoUrl = process.env.EXPO_URL || "";
+const RUNTIME_DIR = path.join(__dirname, ".runtime");
+const URL_FILE = path.join(RUNTIME_DIR, "expo-url.json");
+fs.mkdirSync(RUNTIME_DIR, { recursive: true });
 
-const EXPO_PORT = Number(process.env.EXPO_PORT || 8081);
-const PID_FILE = path.join(__dirname, ".expo-process.json");
+const URL_REGEX = /(exp(?:s)?:\/\/[^\s]+|https?:\/\/(?:u\.expo\.dev|expo\.dev)[^\s]*)/i;
 
-function requestExpoStatus() {
-  return new Promise((resolve) => {
-    const request = http.get(
-      {
-        hostname: "127.0.0.1",
-        port: EXPO_PORT,
-        path: "/status",
-        timeout: 2000,
+let latestUrl = "";
+
+function writeUrl(url) {
+  try {
+    latestUrl = url;
+    fs.writeFileSync(URL_FILE, JSON.stringify({ url, ts: Date.now() }), "utf8");
+  } catch (err) {
+    console.error("[launcher] Failed to write Expo URL", err);
+  }
+}
+
+function startExpo() {
+  console.log("[launcher] Starting Expo dev server in CI tunnel mode...");
+  const child = spawn(
+    "npx",
+    ["expo", "start", "--tunnel", "--non-interactive"],
+    {
+      cwd: path.join(__dirname, ".."),
+      env: {
+        ...process.env,
+        CI: "false",
+        EXPO_NO_TELEMETRY: "1",
+        EXPO_USE_DEV_SERVER: "1"
       },
-      (res) => {
-        let raw = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          raw += chunk;
-        });
-        res.on("end", () => {
-          if (!raw) {
-            resolve({ ok: res.statusCode === 200, data: null });
-            return;
-          }
-          try {
-            const parsed = JSON.parse(raw);
-            resolve({ ok: res.statusCode === 200, data: parsed });
-          } catch (error) {
-            resolve({ ok: res.statusCode === 200, data: null });
-          }
-        });
-      }
-    );
-
-    request.on("error", () => resolve({ ok: false, data: null }));
-    request.on("timeout", () => {
-      request.destroy();
-      resolve({ ok: false, data: null });
-    });
-  });
-}
-
-function parseExpoUrl(text) {
-  const matches = text.match(/(exp:\/\/[^\s]+|https?:\/\/[^\s]+expo\.[^\s]+)/i);
-  if (!matches) {
-    return;
-  }
-  const [match] = matches;
-  if (match && match !== latestExpoUrl) {
-    latestExpoUrl = match.trim();
-    expoEvents.emit("url", latestExpoUrl);
-    console.log(`[launcher] Expo tunnel URL detected: ${latestExpoUrl}`);
-  }
-}
-
-function logStream(stream, prefix) {
-  if (!stream) return;
-  stream.on("data", (chunk) => {
-    const text = chunk.toString();
-    text.split(/\r?\n/).forEach((line, index, arr) => {
-      if (!line && index === arr.length - 1) return;
-      console.log(`${prefix}${line}`);
-    });
-    parseExpoUrl(text);
-  });
-}
-
-function logErrorStream(stream, prefix) {
-  if (!stream) return;
-  stream.on("data", (chunk) => {
-    const text = chunk.toString();
-    text.split(/\r?\n/).forEach((line, index, arr) => {
-      if (!line && index === arr.length - 1) return;
-      console.error(`${prefix}${line}`);
-    });
-  });
-}
-
-function processExists(pid) {
-  if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
-
-export function getRecordedExpoProcess() {
-  try {
-    const raw = fs.readFileSync(PID_FILE, "utf8");
-    const data = JSON.parse(raw);
-    if (data?.pid && processExists(data.pid)) {
-      return data.pid;
+      stdio: ["ignore", "pipe", "pipe"]
     }
-  } catch (error) {
-    // ignore read errors
-  }
-  return null;
-}
+  );
 
-function recordExpoProcess(pid) {
-  if (!pid) return;
-  try {
-    fs.writeFileSync(PID_FILE, JSON.stringify({ pid }), "utf8");
-  } catch (error) {
-    console.error("[launcher] Failed to persist Expo process PID:", error);
+  if (latestUrl) {
+    writeUrl(latestUrl);
   }
-}
 
-function clearRecordedProcess() {
-  try {
-    if (fs.existsSync(PID_FILE)) {
-      fs.unlinkSync(PID_FILE);
+  child.stdout.on("data", (buf) => {
+    const line = buf.toString();
+    process.stdout.write(line);
+    const m = line.match(URL_REGEX);
+    if (m) {
+      const url = m[1];
+      console.log("[launcher] Detected Expo URL:", url);
+      writeUrl(url);
     }
-  } catch (error) {
-    console.error("[launcher] Failed to remove Expo process record:", error);
-  }
-}
-
-export function startExpo(options = {}) {
-  const { detached = false, force = false } = options;
-
-  if (!force && expoProcess && !expoProcess.killed) {
-    return expoProcess;
-  }
-
-  if (!force) {
-    const recordedPid = getRecordedExpoProcess();
-    if (recordedPid) {
-      console.log(
-        `[launcher] Detected running Expo process with PID ${recordedPid}. Skipping new spawn.`
-      );
-      return expoProcess;
-    }
-  }
-
-  const projectRoot = path.resolve(__dirname, "..", "");
-
-  const child = spawn("npx", ["expo", "start", "--tunnel"], {
-    cwd: projectRoot,
-    env: { ...process.env },
-    stdio: detached ? "inherit" : ["ignore", "pipe", "pipe"],
-    shell: false,
-    detached,
   });
 
-  recordExpoProcess(child.pid);
+  child.stderr.on("data", (buf) => {
+    const line = buf.toString();
+    process.stderr.write(line);
+    const m = line.match(URL_REGEX);
+    if (m) {
+      const url = m[1];
+      console.log("[launcher] Detected Expo URL (stderr):", url);
+      writeUrl(url);
+    }
+  });
+
+  child.on("exit", (code) => {
+    console.error("[launcher] Expo process exited with code", code, "- restarting in 5s");
+    setTimeout(startExpo, 5000);
+  });
 
   child.on("error", (error) => {
-    console.error("[launcher] Expo process error:", error);
+    console.error("[launcher] Failed to start Expo process:", error);
   });
-
-  child.on("exit", (code, signal) => {
-    expoProcess = null;
-    clearRecordedProcess();
-    if (code === 0) {
-      console.log("[launcher] Expo process exited cleanly.");
-    } else {
-      console.error(
-        `[launcher] Expo process exited with code ${code}${signal ? ` (signal ${signal})` : ""}.`
-      );
-    }
-  });
-
-  if (detached) {
-    try {
-      child.unref();
-    } catch (error) {
-      console.error("[launcher] Failed to detach Expo process:", error);
-    }
-  } else {
-    logStream(child.stdout, "[expo] ");
-    logErrorStream(child.stderr, "[expo] ");
-  }
-
-  expoProcess = child;
-  return child;
 }
 
-export function getExpoUrl() {
-  return latestExpoUrl;
-}
-
-export function onExpoUrlUpdate(listener) {
-  expoEvents.on("url", listener);
-  if (latestExpoUrl) {
-    listener(latestExpoUrl);
-  }
-  return () => expoEvents.off("url", listener);
-}
-
-export async function isExpoRunning() {
-  if (getRecordedExpoProcess()) {
-    return true;
-  }
-
-  const status = await requestExpoStatus();
-  return status.ok;
-}
-
-export async function getExpoStatus() {
-  const status = await requestExpoStatus();
-  return status.data || null;
-}
-
-if (process.argv[1] === __filename) {
-  const runningCheck = await isExpoRunning();
-  if (runningCheck) {
-    console.log("[launcher] Expo dev server already running. Skipping new spawn.");
-  } else {
-    console.log("[launcher] Starting Expo dev server in detached mode...");
-    startExpo({ detached: true, force: true });
-  }
-}
+startExpo();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^7.0.14",
     "@types/dagre": "^0.7.53",
     "dagre": "^0.8.5",
+    "@expo/ngrok": "^4.1.0",
     "expo": "^53.0.0",
     "expo-blur": "~14.1.3",
     "expo-camera": "~16.1.5",

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "numReplicas": 1,
-    "startCommand": "npm --prefix launcher install && node launcher/start-expo.js && npm --prefix launcher start",
+    "startCommand": "CI=false npm install && CI=false npm --prefix launcher install && CI=false node launcher/start-expo.js & CI=false npm --prefix launcher start",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100
   }


### PR DESCRIPTION
## Summary
- add the @expo/ngrok dependency and document the automated Expo tunnel workflow for Railway
- replace the launcher start-expo helper with a CI-friendly tunnel runner that writes the latest Expo URL to a runtime file
- simplify the launcher server to serve the discovered URL via /config.js and update Railway to install dependencies before running both processes

## Testing
- npm install *(fails in container with 403 for @expo/ngrok)*

------
https://chatgpt.com/codex/tasks/task_e_68e001ecd370832aa84355367b37f9ad