### PR TITLE
Add lockfile entry for Expo ngrok dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,11 @@
         }
       }
     },
+    "node_modules/@expo/ngrok": {
+      "version": "4.1.3",
+      "resolved": "git+https://github.com/expo/ngrok.git#4.1.3",
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",


### PR DESCRIPTION
## Summary
- add a lockfile entry for `@expo/ngrok` so Railway installs the tunnel dependency

## Testing
- not run (network access to npm registry is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e007375d7c832aa9e2db46bbfffaca