### PR TITLE
Remove unused expo ngrok dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "bolt-expo-starter",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/ngrok": "^4.1.3",
         "@expo/vector-icons": "^14.1.0",
         "@lucide/lab": "^0.1.2",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -68,11 +67,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@expo/ngrok": {
-      "version": "4.1.3",
-      "resolved": "git+https://github.com/expo/ngrok.git#4.1.3",
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@react-navigation/native": "^7.0.14",
     "@types/dagre": "^0.7.53",
     "dagre": "^0.8.5",
-    "@expo/ngrok": "^4.1.3",
     "expo": "^53.0.0",
     "expo-blur": "~14.1.3",
     "expo-camera": "~16.1.5",


### PR DESCRIPTION
## Summary
- remove the unused @expo/ngrok dependency that required a missing git tag
- update the lockfile accordingly to unblock npm ci during Docker builds

## Testing
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68e00b62a248832a9cd0106b8f4a306e