### PR TITLE
Add dynamic Expo URL polling to Railway launcher

### DIFF
--- a/launcher/public/index.html
+++ b/launcher/public/index.html
@@ -29,6 +29,7 @@
         <div><strong>Expo URL:</strong> <code id="url"></code></div>
         <div class="warn" id="warn"></div>
       </div>
+      <div class="row" id="statusRow" style="opacity: 0.75; font-size: 0.9rem;"></div>
       <div class="qr"><canvas id="qrcode"></canvas></div>
       <a id="open" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Open in Expo Go</a>
     </div>
@@ -49,22 +50,82 @@
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
   <script>
     (function () {
-      const expoUrl = window.__EXPO_URL__ || "";
+      const initial = window.__EXPO_CONFIG__ || { url: window.__EXPO_URL__ || "", source: "none" };
       const urlEl = document.getElementById("url");
       const warnEl = document.getElementById("warn");
       const btn = document.getElementById("open");
       const canvas = document.getElementById("qrcode");
+      const statusRow = document.getElementById("statusRow");
 
-      urlEl.textContent = expoUrl || "(not set)";
-      btn.href = expoUrl || "#";
+      let lastUrl = "";
+      let isPolling = false;
 
-      if (!expoUrl) {
-        warnEl.textContent = "Set EXPO_URL env var on Railway to show QR and enable the button.";
-      } else {
-        QRCode.toCanvas(canvas, expoUrl, { width: 260 }, function (err) {
+      function clearCanvas() {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          ctx.clearRect(0, 0, canvas.width || 0, canvas.height || 0);
+        }
+      }
+
+      function describeSource(info) {
+        if (!info.url) return "Waiting for Expo dev server to report a tunnel URL...";
+        if (info.source === "env") return "Using EXPO_URL from Railway environment variables.";
+        if (info.source === "runtime") {
+          const updated = info.updated ? new Date(info.updated).toLocaleString() : "just now";
+          return `Detected from Expo CLI logs (updated ${updated}).`;
+        }
+        return "URL detected.";
+      }
+
+      function applyInfo(info) {
+        const url = info.url || "";
+        urlEl.textContent = url || "(not yet detected)";
+        btn.href = url || "#";
+        btn.setAttribute("aria-disabled", url ? "false" : "true");
+        warnEl.textContent = url ? "" : "The Expo tunnel starts automatically on Railway. This page will refresh when it is ready.";
+        statusRow.textContent = describeSource(info);
+
+        if (!url) {
+          if (lastUrl) {
+            clearCanvas();
+          }
+          lastUrl = "";
+          return;
+        }
+
+        if (url === lastUrl) return;
+        lastUrl = url;
+
+        QRCode.toCanvas(canvas, url, { width: 260 }, function (err) {
           if (err) console.error(err);
         });
       }
+
+      async function poll() {
+        if (isPolling) return;
+        isPolling = true;
+
+        const pollIntervalMs = 3500;
+
+        async function loop() {
+          try {
+            const res = await fetch(`/runtime.json?ts=${Date.now()}`, { cache: "no-store" });
+            if (res.ok) {
+              const info = await res.json();
+              applyInfo(info);
+            }
+          } catch (err) {
+            console.warn("Failed to fetch runtime info", err);
+          } finally {
+            setTimeout(loop, pollIntervalMs);
+          }
+        }
+
+        loop();
+      }
+
+      applyInfo(initial);
+      poll();
     })();
   </script>
 </body>

--- a/launcher/server.js
+++ b/launcher/server.js
@@ -12,6 +12,31 @@ const PORT = process.env.PORT || 3000;
 const PUBLIC_DIR = path.join(__dirname, "public");
 const RUNTIME_URL_FILE = path.join(__dirname, ".runtime", "expo-url.json");
 
+function readRuntimeFile() {
+  try {
+    if (!fs.existsSync(RUNTIME_URL_FILE)) return null;
+    const data = JSON.parse(fs.readFileSync(RUNTIME_URL_FILE, "utf8"));
+    const url = typeof data?.url === "string" ? data.url.trim() : "";
+    if (!url) return null;
+    return { url, source: "runtime", updated: data?.ts ?? null };
+  } catch (err) {
+    console.warn("Failed to read Expo runtime URL", err);
+    return null;
+  }
+}
+
+function resolveExpoUrl() {
+  const runtime = readRuntimeFile();
+  if (runtime) return runtime;
+
+  const envUrl = typeof process.env.EXPO_URL === "string" ? process.env.EXPO_URL.trim() : "";
+  if (envUrl) {
+    return { url: envUrl, source: "env", updated: null };
+  }
+
+  return { url: "", source: "none", updated: null };
+}
+
 app.use(express.static(PUBLIC_DIR));
 
 app.get("/health", (_req, res) => {
@@ -19,15 +44,19 @@ app.get("/health", (_req, res) => {
 });
 
 app.get("/config.js", (_req, res) => {
+  const info = resolveExpoUrl();
   res.setHeader("Content-Type", "application/javascript");
-  let url = process.env.EXPO_URL || "";
-  try {
-    if (fs.existsSync(RUNTIME_URL_FILE)) {
-      const j = JSON.parse(fs.readFileSync(RUNTIME_URL_FILE, "utf8"));
-      if (j && j.url) url = j.url;
-    }
-  } catch {}
-  res.end(`window.__EXPO_URL__ = ${JSON.stringify(url)};`);
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+  res.end(
+    `window.__EXPO_CONFIG__ = ${JSON.stringify(info)}; window.__EXPO_URL__ = ${JSON.stringify(info.url)};`
+  );
+});
+
+app.get("/runtime.json", (_req, res) => {
+  const info = resolveExpoUrl();
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+  res.json(info);
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- expose the detected Expo URL metadata from the launcher server and serve a JSON endpoint for polling
- update the launcher page to consume the new endpoint, show status messaging, and refresh the QR code automatically

## Testing
- curl http://127.0.0.1:3000/config.js
- curl http://127.0.0.1:3000/runtime.json

------
https://chatgpt.com/codex/tasks/task_e_68e011609f18832a91c603c494a4d8ae