### PR TITLE
Fix Expo launcher non-interactive failure

### DIFF
--- a/launcher/start-expo.js
+++ b/launcher/start-expo.js
@@ -20,12 +20,12 @@ function startExpo() {
   console.log("[launcher] Starting Expo dev server in CI tunnel mode...");
   const child = spawn(
     "npx",
-    ["expo", "start", "--tunnel", "--non-interactive"],
+    ["expo", "start", "--tunnel"],
     {
       cwd: path.join(__dirname, ".."), // project root (one level up)
       env: {
         ...process.env,
-        CI: "false",
+        CI: "1",
         EXPO_NO_TELEMETRY: "1",
         EXPO_USE_DEV_SERVER: "1"
       },


### PR DESCRIPTION
## Summary
- update the launcher script to rely on CI=1 instead of the deprecated --non-interactive flag
- ensure the Expo dev server starts in CI tunnel mode without prompting for input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e013bff478832a9a707350bf36e02f