### PR TITLE
Add workflow to auto merge PRs into main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,37 @@
+name: Auto-merge PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number,
+                merge_method: 'squash'
+              });
+              core.info(`Pull request #${pull_number} merged into main.`);
+            } catch (error) {
+              core.setFailed(`Failed to merge pull request: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that automatically merges pull requests targeting main as soon as they are opened or updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01439af38832a90156df7a48ced26