### PR TITLE
Graph canvas: cursor-anchored zoom, double-click creation, grid, and Bezier connectors

### DIFF
--- a/app/projects/[id].tsx
+++ b/app/projects/[id].tsx
@@ -113,7 +113,13 @@ export default function ProjectDetailScreen() {
 
     const finalPosition = nodePosition ?? { x: 100, y: 100 };
     const now = new Date().toISOString();
-    const meta = childData?.meta ?? (standaloneRoot ? { standaloneRoot: true } : undefined);
+    const meta = {
+      ...(standaloneRoot ? { standaloneRoot: true } : {}),
+      ...(childData?.meta ?? {}),
+    };
+    if (!meta.nodeType) {
+      meta.nodeType = 'process';
+    }
 
     const newNode: Node = {
       id: Date.now().toString(),
@@ -131,7 +137,7 @@ export default function ProjectDetailScreen() {
       ...childData,
       parentId: effectiveParentId,
       position: childData?.position ?? finalPosition,
-      meta,
+      meta: Object.keys(meta).length ? meta : undefined,
     };
 
     try {
@@ -156,8 +162,12 @@ export default function ProjectDetailScreen() {
     }
   };
 
-  const handleCanvasPress = (position: { x: number; y: number }) => {
-    handleCreateNode(undefined, position);
+  const handleCanvasPress = (
+    position: { x: number; y: number },
+    options?: { shiftKey?: boolean; source?: 'tap' | 'double-click' | 'button' },
+  ) => {
+    const nodeType = options?.shiftKey ? 'task' : 'process';
+    handleCreateNode(undefined, position, { meta: { nodeType } });
   };
 
   const handleSaveNode = async (nodeData: Partial<Node>) => {

--- a/components/graph/GraphEdge.tsx
+++ b/components/graph/GraphEdge.tsx
@@ -4,7 +4,7 @@ import { Path } from 'react-native-svg';
 import { useGraphSnapshot } from './GraphRegistry';
 import {
   arrowHeadPath,
-  edgePathForRects,
+  bezierPathForRects,
 } from '@/utils/graphUtils';
 
 const AnimatedPath = Animated.createAnimatedComponent(Path);
@@ -19,9 +19,7 @@ interface GraphEdgeProps {
 
 const DEFAULT_COLOR = '#0E7AFE';
 const EDGE_RADIUS = 14;
-const EDGE_PADDING = 20;
 const EPSILON = 0.5;
-
 export function GraphEdge({ from, to, strokeWidth = 2.5, color = DEFAULT_COLOR, kind }: GraphEdgeProps) {
   const graph = useGraphSnapshot();
   const parent = graph.get(from);
@@ -52,19 +50,27 @@ export function GraphEdge({ from, to, strokeWidth = 2.5, color = DEFAULT_COLOR, 
       return { path: '', arrow: '' };
     }
 
-    const pathResult = edgePathForRects(parentRect, childRect, EDGE_RADIUS, EDGE_PADDING);
+    const pathResult = bezierPathForRects(parentRect, childRect);
 
-    if (!pathResult.d || pathResult.points.length < 2) {
+    if (!pathResult.d) {
       return { path: '', arrow: '' };
     }
 
-    const points = pathResult.points;
-    const tip = points[points.length - 1];
-    const tail = points[points.length - 2];
+    const tip = pathResult.to.anchor;
+    const approachX = tip.x - pathResult.c2.x;
+    const approachY = tip.y - pathResult.c2.y;
+    const approachLength = Math.hypot(approachX, approachY);
 
-    if (!tip || !tail || (Math.abs(tail.x - tip.x) < EPSILON && Math.abs(tail.y - tip.y) < EPSILON)) {
+    if (approachLength < EPSILON) {
       return { path: pathResult.d, arrow: '' };
     }
+
+    const ux = approachX / approachLength;
+    const uy = approachY / approachLength;
+    const tail = {
+      x: tip.x - ux * (EDGE_RADIUS + 6),
+      y: tip.y - uy * (EDGE_RADIUS + 6),
+    };
 
     const arrow = arrowHeadPath(tail, tip, EDGE_RADIUS + 4, EDGE_RADIUS);
     return { path: pathResult.d, arrow };
@@ -77,6 +83,16 @@ export function GraphEdge({ from, to, strokeWidth = 2.5, color = DEFAULT_COLOR, 
 
   return (
     <>
+      <AnimatedPath
+        animatedProps={animatedEdgeProps}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth * 3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.18}
+        pointerEvents="none"
+      />
       <AnimatedPath
         animatedProps={animatedEdgeProps}
         fill="none"

--- a/components/project/ProjectCanvas.tsx
+++ b/components/project/ProjectCanvas.tsx
@@ -25,7 +25,10 @@ interface ProjectCanvasProps {
   onNodeMove: (nodeId: string, position: { x: number; y: number }) => void;
   onCreateNode: (parentId?: string, position?: { x: number; y: number }, nodeData?: any) => void;
   onUpdateNode: (nodeId: string, updates: Partial<Node>) => void;
-  onCanvasPress: (position: { x: number; y: number }) => void;
+  onCanvasPress: (
+    position: { x: number; y: number },
+    options?: { shiftKey?: boolean; source?: 'tap' | 'double-click' | 'button' },
+  ) => void;
 }
 
 export function ProjectCanvas({
@@ -76,8 +79,11 @@ export function ProjectCanvas({
     onNodeMove(id, { x, y });
   };
 
-  const handleCanvasPress = (position: { x: number; y: number }) => {
-    onCanvasPress(position);
+  const handleCanvasPress = (
+    position: { x: number; y: number },
+    options?: { shiftKey?: boolean; source?: 'tap' | 'double-click' | 'button' },
+  ) => {
+    onCanvasPress(position, options);
   };
 
   // Cards View
@@ -163,7 +169,11 @@ export function ProjectCanvas({
       <View style={[styles.header, { backgroundColor: colors.background, borderBottomColor: colors.border }]}>
         <ViewModeToggle mode={viewMode} onModeChange={setViewMode} />
         <Text style={[styles.instructionText, { color: colors.textSecondary }]}>
-          {viewMode === 'graph' ? 'Two-finger tap to create nodes' : 'Tap cards to edit'}
+          {viewMode === 'graph'
+            ? (Platform.OS === 'web'
+              ? 'Double-click to create nodes • Shift + double-click for tasks'
+              : 'Two-finger tap to create nodes')
+            : 'Tap cards to edit'}
         </Text>
       </View>
 


### PR DESCRIPTION
### Motivation

- Improve the canvas interaction model for web and touch so zooming feels cursor-anchored and node creation is gesture-friendly. 
- Replace rigid orthogonal edges with smoother Bezier connectors to make relationships feel more natural and visually appealing. 
- Surface node type metadata and lightweight status indicators so tasks and processes are visually distinguishable and show activity at-a-glance. 

### Description

- Implemented cursor-anchored wheel zoom and `onDoubleClick` handling in `GraphCanvas` and expanded the canvas size while rendering a subtle SVG grid background via `Defs`/`Pattern`, and extended the `onCanvasPress` signature to accept `options` like `shiftKey` and `source`. 
- Added `bezierPathForRects` to `utils/graphUtils.ts` and updated `GraphEdge` to use Bezier curves with a faint glow/backdrop path and refined arrowhead placement for better visual quality. 
- Added node type metadata (`meta.nodeType`) defaulting to `process`, propagate `meta` into the canvas nodes, and make `Shift + double-click` create a `task` node while `double-click` creates a `process`. 
- Enhanced `GraphNode` to show a compact type badge and an animated pulsing LED when status is `in-progress`, and updated `ProjectCanvas` / `app/projects/[id].tsx` to forward creation options and set node metadata on creation. 

### Testing

- Attempted to run the web dev server with `npm run dev -- --web`, but the Expo CLI start failed with a network `fetch failed` error so the app was not live-tested. 
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd531e5f4832a9653f4ab11f38b55)